### PR TITLE
Deliver unallocated Pod events to SchedulerAlgorithm

### DIFF
--- a/pkg/algorithm/hived_algorithm.go
+++ b/pkg/algorithm/hived_algorithm.go
@@ -195,6 +195,12 @@ func (h *HivedAlgorithm) Schedule(pod *core.Pod, suggestedNodes []string) intern
 		pod)
 }
 
+func (h *HivedAlgorithm) AddUnallocatedPod(pod *core.Pod) {
+}
+
+func (h *HivedAlgorithm) DeleteUnallocatedPod(pod *core.Pod) {
+}
+
 func (h *HivedAlgorithm) AddAllocatedPod(pod *core.Pod) {
 	h.algorithmLock.Lock()
 	defer h.algorithmLock.Unlock()

--- a/pkg/internal/types.go
+++ b/pkg/internal/types.go
@@ -64,8 +64,8 @@ type InspectHandlers struct {
 //    logs, other Panics will crash the whole process, see HandleWebServerPanic.
 // 2. Should take all the input parameters as readonly and return pod schedule
 //    decision by PodScheduleResult.
-// 3. {Schedule, AddAllocatedPod, DeleteAllocatedPod, AddUnallocatedPod,
-//    DeleteUnallocatedPod} will never be executed concurrently for all pods.
+// 3. {Schedule, AddUnallocatedPod, DeleteUnallocatedPod, AddAllocatedPod,
+//    DeleteAllocatedPod} will never be executed concurrently for all pods.
 // 4. [Schedule -> (AddAllocatedPod) -> Schedule -> ...] is executed sequentially
 //    for all pods.
 //    I.e. the constructed scheduling view is already lock protected.
@@ -82,13 +82,13 @@ type SchedulerAlgorithm interface {
 	UpdateNode(oldNode, newNode *core.Node)
 	DeleteNode(node *core.Node)
 
-	// Track all current allocated and unallocated Pods in the whole cluster.
-	// Allocated Pod includes both PodBound and PodBinding Pods.
-	AddAllocatedPod(pod *core.Pod)
-	DeleteAllocatedPod(pod *core.Pod)
+	// Track all current unallocated and allocated Pods in the whole cluster.
 	// Unallocated Pod includes both PodWaiting and PodPreempting Pods.
 	AddUnallocatedPod(pod *core.Pod)
 	DeleteUnallocatedPod(pod *core.Pod)
+	// Allocated Pod includes both PodBound and PodBinding Pods.
+	AddAllocatedPod(pod *core.Pod)
+	DeleteAllocatedPod(pod *core.Pod)
 
 	// Expose current scheduling status
 	GetAllAffinityGroups() si.AffinityGroupList

--- a/pkg/internal/types.go
+++ b/pkg/internal/types.go
@@ -65,7 +65,7 @@ type InspectHandlers struct {
 // 2. Should take all the input parameters as readonly and return pod schedule
 //    decision by PodScheduleResult.
 // 3. {Schedule, AddAllocatedPod, DeleteAllocatedPod, AddUnallocatedPod,
-// 		DeleteUnallocatedPod} will never be executed concurrently for all pods.
+//    DeleteUnallocatedPod} will never be executed concurrently for all pods.
 // 4. [Schedule -> (AddAllocatedPod) -> Schedule -> ...] is executed sequentially
 //    for all pods.
 //    I.e. the constructed scheduling view is already lock protected.

--- a/pkg/internal/types.go
+++ b/pkg/internal/types.go
@@ -64,8 +64,8 @@ type InspectHandlers struct {
 //    logs, other Panics will crash the whole process, see HandleWebServerPanic.
 // 2. Should take all the input parameters as readonly and return pod schedule
 //    decision by PodScheduleResult.
-// 3. {Schedule, AddAllocatedPod, DeleteAllocatedPod} will never be executed
-//    concurrently for all pods.
+// 3. {Schedule, AddAllocatedPod, DeleteAllocatedPod, AddUnallocatedPod,
+// 		DeleteUnallocatedPod} will never be executed concurrently for all pods.
 // 4. [Schedule -> (AddAllocatedPod) -> Schedule -> ...] is executed sequentially
 //    for all pods.
 //    I.e. the constructed scheduling view is already lock protected.
@@ -82,10 +82,13 @@ type SchedulerAlgorithm interface {
 	UpdateNode(oldNode, newNode *core.Node)
 	DeleteNode(node *core.Node)
 
-	// Track all current allocated Pods in the whole cluster.
+	// Track all current allocated and unallocated Pods in the whole cluster.
 	// Allocated Pod includes both PodBound and PodBinding Pods.
 	AddAllocatedPod(pod *core.Pod)
 	DeleteAllocatedPod(pod *core.Pod)
+	// Unallocated Pod includes both PodWaiting and PodPreempting Pods.
+	AddUnallocatedPod(pod *core.Pod)
+	DeleteUnallocatedPod(pod *core.Pod)
 
 	// Expose current scheduling status
 	GetAllAffinityGroups() si.AffinityGroupList


### PR DESCRIPTION
This helps SchedulerAlgorithm to be stateful with unallocated Pod, such as stateful preemption.